### PR TITLE
Multi planet system search

### DIFF
--- a/data/config/seedreporterConfig/seedreporterSettings.json
+++ b/data/config/seedreporterConfig/seedreporterSettings.json
@@ -6,10 +6,29 @@
 	# If true, a SEED Report will be executed upon starting a new game
 	"runSEEDReportOnGameStart": true,
 
+	# ============================================================================
+	# IMPORTANT: Star System Filter Execution Order
+	# ============================================================================
+	# Star system filters are executed in the order they appear in this file.
+	# If filterB references filterA via nearSystemFiltersRequired or
+	# nearSystemFiltersOptional, then filterA MUST be defined BEFORE filterB.
+	#
+	# Recommended order:
+	#   1. Base filters (gate, hypershunt, cryosleeper, etc.)
+	#   2. Compound filters that reference base filters
+	#   3. Complex filters that reference compound filters
+	#
+	# Example:
+	#   "hypershunt": {...},                    // Define first
+	#   "nearHypershunt": {                     // Can reference "hypershunt"
+	#     "nearSystemFiltersRequired": [["hypershunt", 10.0]]
+	#   }
+	# ============================================================================
+
 	"starSystemFilters": {
 		"example": {
 			# Name of the filter, which will be displayed on the report.
-			"filterName": "Example filter",
+			"filterName": "Example system filter",
 
 			# If specified, any seed that passes this filter will be saved to seedreporter_savedSeeds.json,
 			# using the given shorthand alongside the seed string information
@@ -31,9 +50,54 @@
 				"theme_core"
 			],
 
-			# If specified, Oonly search for systems that contain an entity with all specified tags
+			# If specified, only search for systems that contain an entity with all specified tags
 			"hasEntityWithTags": [
 				"station"
+			],
+			
+			# If specified, only systems within this distance (LY) from the market center of mass will match
+			"distanceFromCOM": 25.0,
+			
+			# If specified, only systems with at least this many stable locations will match
+			# Includes both empty stable locations and system objectives like Comm Relays, Sensor Arrays, or Nav Buoys
+			"numStableLocations": 3,
+			
+			# If specified, only systems near (within X LY of) systems from other filters will match (REQUIRED)
+			# Can specify just filter name (must be IN that system) or [filter name, distance]
+			# Examples:
+			#   ["gate"]                           - Must have a gate
+			#   [["domainCryosleeper", 5.0]]       - Within 5 LY of a cryosleeper
+			#   ["gate", ["hypershunt", 10.0]]     - Must have a gate AND be within 10 LY of hypershunt
+			"nearSystemFiltersRequired": [
+				"gate",
+				["domainCryosleeper", 10.0],
+				["hypershunt", 10.0]
+			],
+			
+			# Optional proximity - nice to have, shown in output with + prefix
+			"nearSystemFiltersOptional": [
+				["hypershunt", 5.0]
+			],
+			
+			# If specified, only systems that contain ALL of these planets will match (AND logic)
+			# Planet filter IDs reference filters defined in "planetFilters" section
+			# Can specify count: ["habitablePlanet", 3] means at least 3 habitable planets
+			# When planet requirements are used, the report shows which planets matched
+			"hasPlanetsRequired": [
+				["habitablePlanet", 2],    # At least 2 habitable planets
+				"noAtmospherePlanet"       # At least 1 barren planet
+			],
+			
+			# If specified, only systems with AT LEAST ONE of these planets will match (OR logic)
+			# Only one OR block is supported per filter
+			"hasPlanetsOneOf": [
+				"gasGiant",
+				"solarArrayPlanet"
+			],
+			
+			# Optional planets - nice to have, shown in output with + prefix
+			"hasPlanetsOptional": [
+				"farmingPlanet"
 			]
 		},
 		"sentinel": {
@@ -98,55 +162,151 @@
 				"gate"
 			],
 		},
+		"barrenGateSystem": {
+			"filterName": "System with gate and Barren planet (20 LY)",
+			"isEnabled": true,
+			"distanceFromCOM": 20,
+			"avoidTags": [
+				"theme_hidden",
+				"theme_core",
+				"theme_abyssal"
+			],
+			"hasEntityWithTags": [
+				"gate"
+			],
+			"hasPlanetsRequired": [
+				"barrenLowHazard"
+			]
+		},
+		"gasGiantGateSystem": {
+			"filterName": "System with gate and Gas Giant (Plentiful Volatiles, 20 LY)",
+			"saveShorthand": "G",
+			"isEnabled": true,
+			"distanceFromCOM": 20,
+			"avoidTags": [
+				"theme_hidden",
+				"theme_core",
+				"theme_abyssal"
+			],
+			"hasEntityWithTags": [
+				"gate"
+			],
+			"hasPlanetsRequired": [
+				"gasGiantPlentifulVolatiles"
+			]
+		},
+		"orbitalSolarArraySystem": {
+			"filterName": "Orbital Solar Array planets",
+			"saveShorthand": "S",
+			"isEnabled": true,
+			"avoidTags": [
+				"theme_hidden",
+				"theme_core",
+				"theme_abyssal"
+			],
+			"hasPlanetsRequired": [
+				"orbitalSolarArrayPlanet"
+			]
+		},
+		"miningBoreSystem": {
+			"filterName": "Autonomous Mining Bore with all 4 resources",
+			"saveShorthand": "A",
+			"isEnabled": true,
+			"avoidTags": [
+				"theme_hidden",
+				"theme_core",
+				"theme_abyssal"
+			],
+			"hasPlanetsRequired": [
+				"miningBorePlanet"
+			]
+		},
+		"soilNanitesSystem": {
+			"filterName": "Soil Nanites and Fullerene Spool on non-decivilized world",
+			"saveShorthand": "N",
+			"isEnabled": true,
+			"avoidTags": [
+				"theme_hidden",
+				"theme_core",
+				"theme_abyssal"
+			],
+			"hasPlanetsRequired": [
+				"soilNanitesPlanet"
+			]
+		},
+		"basicOneSystemBuild": {
+			"filterName": "Basic one-system colony build",
+			"saveShorthand": "1SYS",
+			"isEnabled": true,
+			"distanceFromCOM": 25,
+			"avoidTags": [
+				"theme_hidden",
+				"theme_core",
+				"theme_abyssal"
+			],
+			"hasPlanetsRequired": [
+				"habitablePlanet",
+				"farmingPlanet",
+				"noAtmospherePlanet",
+				"planetWithOres",
+				"planetWithOrganics",
+				"gasGiantAny"
+			],
+			"nearSystemFiltersOptional": [
+				"gate",
+				["hypershunt", 10.0],
+				["domainCryosleeper", 10.0]
+			]
+		},
+		"multiHabitableSystem": {
+			"filterName": "System with 3+ habitable planets",
+			"saveShorthand": "3HAB",
+			"isEnabled": true,
+			"distanceFromCOM": 25,
+			"avoidTags": [
+				"theme_hidden",
+				"theme_core",
+				"theme_abyssal"
+			],
+			"hasPlanetsRequired": [
+				["habitablePlanet", 3]
+			],
+			"hasPlanetsOptional": [
+				"noAtmospherePlanet",
+				"planetWithOres",
+				"planetWithOrganics",
+				"farmingPlanet",
+				"gasGiantAny"
+			],
+			"nearSystemFiltersOptional": [
+				"gate",
+				["hypershunt", 10.0],
+				["domainCryosleeper", 10.0]
+			]
+		},
 	},
 
 	# Which star system filter (from "starSystemFilters") to use when searching
 	# for Tesseract locations and variants
 	"tesseractStarSystemFilter": "hypershunt",
 
-	# Settings for the planet filters.
-	# Star systems tagged as "theme_core", "theme_hidden", or "system_abyssal"
-	# will be skipped regardless of the filter settings.
+	# Planet filter definitions
+	# Planet filters define reusable planet search criteria that can be referenced by star system filters
+	# All planet filters are component filters - they are not run standalone but used by system filters
 	"planetFilters": {
 		"example": {
-			# Name of the filter, which will be displayed on the report.
-			"filterName": "Example filter",
+			# Name of the filter, which will be displayed on the report if saveShorthand is specified
+			"filterName": "Example planet filter",
 
 			# If specified, any seed that passes this filter will be saved to seedreporter_savedSeeds.json,
-			# using the given shorthand alongside the seed string information
-			"saveShorthand": "e.g.",
+			# This also causes the filter results to be printed in the report
+			# "saveShorthand": "e.g.",  # Commented out so this example doesn't actually run
 
-			# If true, the filter will be activated when running the report.
-			"isEnabled": false,
+			# Only planets with at most this hazard value will match (0-400, where 100 = 100% hazard)
+			"maxHazardValue": 175,
 
-			# If specified, only planets within the specified LY from the market center of mass will show up
-			"distanceFromCOM": 25.0,
-
-			# If specified, the planet must not be in a system with any of these system tags
-			"avoidSystemTags": [
-				"theme_hidden",
-				"theme_core",
-				"system_abyssal"
-			],
-
-			# If specified, the planet must be in or near a system specified in "starSystemFilters"
-			# If a number is included, the planet must be at most that much LY away from the nearest system satisfying the filter
-			"inStarSystemFilters": [
-				"gate",
-				["domainCryosleeper",10.0],
-				["coronalHypershunt",10.0]
-			],
-
-			# Only planets in systems with at least the specified number of stable locations will show up
-			# Includes both empty stable locations and system objectives like Comm Relays, Sensor Arrays, or Nav Buoys
-			"numStableLocations": 3,
-
-			# Only planets in systems with at most the specified hazard value will show up
-			"maxHazardValue": 0,
-
-			# Only these planet types will show up in the filter.
-			# Defining this can speed up the search by avoiding the need to manually search
-			# all conditions in planets that can never host the desired conditions.
+			# Only these planet types will match
+			# Defining this speeds up searches by skipping planets that can't have desired conditions
 			"matchesPlanetTypes": [
 				"gas_giant",
 				"ice_giant",
@@ -180,8 +340,7 @@
 				"barren-desert",
 			],
 
-			# The planet must have a specified number or all of these conditions
-			# to show up in the SEED report.
+			# The planet must have these conditions to match
 			"matchesConditions": [
 				"habitable",
 				"cold",
@@ -236,184 +395,97 @@
 				"solar_array",
 			],
 
-			# Use alongside the "matchesConditions" option!
-			# Show only planets that match at least the specified number.
-			# of conditions - useful if searching within condition groups, like resource deposits.
-			# If omitted, the planet must match ALL conditions in "matchesConditions"
-			# to show up in the SEED report.
+			# Use alongside "matchesConditions"!
+			# Planet must match at least this many conditions (useful for resource deposit groups)
+			# If omitted, planet must match ALL conditions in "matchesConditions"
 			"matchesAtLeast": 4,
 
-			# Planets with the conditions specified here will not
-			# show up in the report.
+			# Planets with any of these conditions will NOT match
 			"avoidConditions": [
-				"habitable",
 				"extreme_tectonic_activity",
 				"extreme_weather",
-				"rare_ore_sparse",
-				"rare_ore_moderate",
-				"rare_ore_abundant",
-				"rare_ore_rich",
-				"rare_ore_ultrarich",
-				"volatiles_trace",
-				"volatiles_diffuse",
-				"volatiles_abundant",
-				"volatiles_plentiful",
 			],
 		},
-		"orbitalSolarArray": {
-			"filterName": "Orbital Solar Array planets",
-			"isEnabled": true,
-			"avoidSystemTags": [
-				"theme_hidden",
-				"theme_core",
-				"system_abyssal"
-			],
-			"matchesPlanetTypes": [
-				# Orbital Solar Arrays only appear on "cat_hab1", "cat_hab2", and "cat_hab3" planets.
-				# Thus, Terran planets (which are in "cat_hab4") cannot get the condition.
-				"terran-eccentric",
-				"jungle",
-				"water",
-				"arid",
-				"tundra",
-				"desert",
-				"desert1",
-				"barren-desert",
-			],
+		
+		# Component filters - used by system filters, not reported standalone
+		"barrenLowHazard": {
+			"filterName": "Barren (<175%)",
+			"matchesPlanetTypes": ["barren", "barren_castiron", "barren2", "barren3", "barren_venuslike", "rocky_metallic", "rocky_unstable", "rocky_ice", "barren-bombarded"],
+			"maxHazardValue": 175
+		},
+		"gasGiantPlentifulVolatiles": {
+			"filterName": "Gas Giant (+2 volatiles, <175%)",
+			"matchesPlanetTypes": ["gas_giant", "ice_giant"],
+			"matchesConditions": ["volatiles_plentiful"],
+			"maxHazardValue": 175,
+			"avoidConditions": ["extreme_weather", "poor_light"]
+		},
+		"orbitalSolarArrayPlanet": {
+			"filterName": "Solar Array",
+			# Orbital Solar Arrays only appear on "cat_hab1", "cat_hab2", and "cat_hab3" planets.
+			# Thus, Terran planets (which are in "cat_hab4") cannot get the condition.
+			"matchesPlanetTypes": ["terran-eccentric", "jungle", "water", "arid", "tundra", "desert", "desert1", "barren-desert"],
+			"matchesConditions": ["solar_array"]
+		},
+		"miningBorePlanet": {
+			"filterName": "Mining Bore (4 resources)",
+			"matchesPlanetTypes": ["toxic", "barren-desert"],
 			"matchesConditions": [
-				"solar_array"
+				"ore_sparse", "ore_moderate", "ore_abundant", "ore_rich", "ore_ultrarich",
+				"rare_ore_sparse", "rare_ore_moderate", "rare_ore_abundant", "rare_ore_rich", "rare_ore_ultrarich",
+				"volatiles_trace", "volatiles_diffuse", "volatiles_abundant", "volatiles_plentiful",
+				"organics_trace", "organics_common", "organics_abundant", "organics_plentiful"
 			],
+			"matchesAtLeast": 4
 		},
-		"miningBore": {
-			"filterName": "Autonomous Mining Bore with all 4 resources",
-			"saveShorthand": "A",
-			"isEnabled": true,
-			"avoidSystemTags": [
-				"theme_hidden",
-				"theme_core",
-				"system_abyssal"
-			],
-			"matchesPlanetTypes": [
-				"toxic",
-				"barren-desert"
-			],
-			"matchesConditions": [
-				"ore_sparse",
-				"ore_moderate",
-				"ore_abundant",
-				"ore_rich",
-				"ore_ultrarich",
-				"rare_ore_sparse",
-				"rare_ore_moderate",
-				"rare_ore_abundant",
-				"rare_ore_rich",
-				"rare_ore_ultrarich",
-				"volatiles_trace",
-				"volatiles_diffuse",
-				"volatiles_abundant",
-				"volatiles_plentiful",
-				"organics_trace",
-				"organics_common",
-				"organics_abundant",
-				"organics_plentiful"
-			],
-			"matchesAtLeast": 4,
-		},
-		"barrenGate": {
-			"filterName": "Barren in Gate system (20 LY)",
-			"isEnabled": true,
-			"distanceFromCOM": 20,
-			"avoidSystemTags": [
-				"theme_hidden",
-				"theme_core",
-				"system_abyssal"
-			],
-			"inStarSystemFilters": [
-				"gate"
-			],
-			"maxHazardValue": 175, # Only 1 25% hazard rating condition
-			"matchesPlanetTypes": [
-				"barren",
-				"barren_castiron",
-				"barren2",
-				"barren3",
-				"barren_venuslike",
-				"rocky_metallic",
-				"rocky_unstable",
-				"rocky_ice",
-				"barren-bombarded"
-			]
-		},
-		"gasGiant": {
-			"filterName": "Gas Giant with Plentiful Volatiles in Gate system (20 LY)",
-			"saveShorthand": "G",
-			"isEnabled": true,
-			"distanceFromCOM": 20,
-			"avoidSystemTags": [
-				"theme_hidden",
-				"theme_core",
-				"system_abyssal"
-			],
-			"inStarSystemFilters": [
-				"gate"
-			],
-			"maxHazardValue": 175, # Only one 25% hazard rating condition at most
-			"matchesPlanetTypes": [
-				"gas_giant",
-				"ice_giant"
-			],
-			"matchesConditions": [
-				"volatiles_plentiful"
-			],
-			# Only allow either Hot or Cold (to enhance or neutralize with Orbital Fusion Lamp)
-			"avoidConditions": [
-				"extreme_weather",
-				"poor_light"
-			],
-		},
-		"soilNanites": {
-			"filterName": "Soil Nanites and Fullerene Spool on non-decivilized world",
-			"isEnabled": true,
-			"avoidSystemTags": [
-				"theme_hidden",
-				"theme_core",
-				"system_abyssal"
-			],
-			"matchesPlanetTypes": [
-				"terran",
-				"terran-eccentric",
-				"jungle",
-				"water",
-				"arid",
-				"tundra",
-				"desert",
-				"desert1",
-			],
-			"matchesConditions": [
-				"farmland_poor",
-				"farmland_adequate",
-				"farmland_rich",
-				"farmland_bountiful"
-			],
+		"soilNanitesPlanet": {
+			"filterName": "Nanites + Spool (non-deciv)",
+			"matchesPlanetTypes": ["terran", "terran-eccentric", "jungle", "water", "arid", "tundra", "desert", "desert1"],
+			"matchesConditions": ["farmland_poor", "farmland_adequate", "farmland_rich", "farmland_bountiful"],
 			"matchesAtLeast": 1,
 			"avoidConditions": [
-				"rare_ore_sparse",
-				"rare_ore_moderate",
-				"rare_ore_abundant",
-				"rare_ore_rich",
-				"rare_ore_ultrarich",
-				"volatiles_trace",
-				"volatiles_diffuse",
-				"volatiles_abundant",
-				"volatiles_plentiful",
-				"extreme_tectonic_activity",
-				"extreme_weather",
-				"decivilized"
+				"rare_ore_sparse", "rare_ore_moderate", "rare_ore_abundant", "rare_ore_rich", "rare_ore_ultrarich",
+				"volatiles_trace", "volatiles_diffuse", "volatiles_abundant", "volatiles_plentiful",
+				"extreme_tectonic_activity", "extreme_weather", "decivilized"
 			]
+		},
+		"habitablePlanet": {
+			"filterName": "Habitable",
+			"matchesPlanetTypes": ["terran", "terran-eccentric", "jungle", "water", "arid", "tundra", "desert", "desert1"],
+			"matchesConditions": ["habitable"]
+		},
+		"noAtmospherePlanet": {
+			"filterName": "No atmosphere",
+			"matchesConditions": ["no_atmosphere"]
+		},
+		"gasGiantAny": {
+			"filterName": "Gas/Ice Giant",
+			"matchesPlanetTypes": ["gas_giant", "ice_giant"]
+		},
+		"planetWithOres": {
+			"filterName": "Ore + Rare Ore",
+			"matchesConditions": [
+				"ore_sparse", "ore_moderate", "ore_abundant", "ore_rich", "ore_ultrarich",
+				"rare_ore_sparse", "rare_ore_moderate", "rare_ore_abundant", "rare_ore_rich", "rare_ore_ultrarich"
+			],
+			"matchesAtLeast": 2
+		},
+		"planetWithOrganics": {
+			"filterName": "Organics",
+			"matchesConditions": [
+				"organics_trace", "organics_common", "organics_abundant", "organics_plentiful"
+			],
+			"matchesAtLeast": 1
+		},
+		"farmingPlanet": {
+			"filterName": "Farmland",
+			"matchesConditions": [
+				"farmland_poor", "farmland_adequate", "farmland_rich", "farmland_bountiful"
+			],
+			"matchesAtLeast": 1
 		},
 		"US_sakura": {
 			"filterName": "Sakura planet (from the Unknown Skies mod)",
-			"isEnabled": false,
 			"matchesPlanetTypes": [
 				"US_sakura"
 			]

--- a/data/config/seedreporterConfig/seedreporterSettings.json
+++ b/data/config/seedreporterConfig/seedreporterSettings.json
@@ -54,16 +54,16 @@
 			"hasEntityWithTags": [
 				"station"
 			],
-			
+
 			# If specified, only systems within this distance (LY) from the market center of mass will match
 			"distanceFromCOM": 25.0,
-			
+
 			# If specified, only systems with at least this many stable locations will match
 			# Includes both empty stable locations and system objectives like Comm Relays, Sensor Arrays, or Nav Buoys
 			"numStableLocations": 3,
-			
-			# If specified, only systems near (within X LY of) systems from other filters will match (REQUIRED)
-			# Can specify just filter name (must be IN that system) or [filter name, distance]
+
+			# If specified, only systems near (within X LY of) systems from other filters will match
+			# Can specify just filter name (must be in that system) or [filter name, distance]
 			# Examples:
 			#   ["gate"]                           - Must have a gate
 			#   [["domainCryosleeper", 5.0]]       - Within 5 LY of a cryosleeper
@@ -73,13 +73,13 @@
 				["domainCryosleeper", 10.0],
 				["hypershunt", 10.0]
 			],
-			
+
 			# Optional proximity - nice to have, shown in output with + prefix
 			"nearSystemFiltersOptional": [
 				["hypershunt", 5.0]
 			],
-			
-			# If specified, only systems that contain ALL of these planets will match (AND logic)
+
+			# If specified, only systems that contain all of these planets will match
 			# Planet filter IDs reference filters defined in "planetFilters" section
 			# Can specify count: ["habitablePlanet", 3] means at least 3 habitable planets
 			# When planet requirements are used, the report shows which planets matched
@@ -87,14 +87,14 @@
 				["habitablePlanet", 2],    # At least 2 habitable planets
 				"noAtmospherePlanet"       # At least 1 barren planet
 			],
-			
-			# If specified, only systems with AT LEAST ONE of these planets will match (OR logic)
+
+			# If specified, only systems with at least one of these planets will match
 			# Only one OR block is supported per filter
 			"hasPlanetsOneOf": [
 				"gasGiant",
 				"solarArrayPlanet"
 			],
-			
+
 			# Optional planets - nice to have, shown in output with + prefix
 			"hasPlanetsOptional": [
 				"farmingPlanet"
@@ -298,10 +298,6 @@
 			# Name of the filter, which will be displayed on the report if saveShorthand is specified
 			"filterName": "Example planet filter",
 
-			# If specified, any seed that passes this filter will be saved to seedreporter_savedSeeds.json,
-			# This also causes the filter results to be printed in the report
-			# "saveShorthand": "e.g.",  # Commented out so this example doesn't actually run
-
 			# Only planets with at most this hazard value will match (0-400, where 100 = 100% hazard)
 			"maxHazardValue": 175,
 
@@ -406,8 +402,6 @@
 				"extreme_weather",
 			],
 		},
-		
-		# Component filters - used by system filters, not reported standalone
 		"barrenLowHazard": {
 			"filterName": "Barren (<175%)",
 			"matchesPlanetTypes": ["barren", "barren_castiron", "barren2", "barren3", "barren_venuslike", "rocky_metallic", "rocky_unstable", "rocky_ice", "barren-bombarded"],

--- a/data/config/seedreporterConfig/seedreporterSettings.json
+++ b/data/config/seedreporterConfig/seedreporterSettings.json
@@ -6,24 +6,27 @@
 	# If true, a SEED Report will be executed upon starting a new game
 	"runSEEDReportOnGameStart": true,
 
-	# ============================================================================
-	# IMPORTANT: Star System Filter Execution Order
-	# ============================================================================
-	# Star system filters are executed in the order they appear in this file.
-	# If filterB references filterA via nearSystemFiltersRequired or
-	# nearSystemFiltersOptional, then filterA MUST be defined BEFORE filterB.
-	#
-	# Recommended order:
-	#   1. Base filters (gate, hypershunt, cryosleeper, etc.)
-	#   2. Compound filters that reference base filters
-	#   3. Complex filters that reference compound filters
-	#
-	# Example:
-	#   "hypershunt": {...},                    // Define first
-	#   "nearHypershunt": {                     // Can reference "hypershunt"
-	#     "nearSystemFiltersRequired": [["hypershunt", 10.0]]
-	#   }
-	# ============================================================================
+	# Star System Filter Execution Order
+	# Filters are executed in the order specified here.
+	# Filters with nearSystemFiltersRequired must appear after the filters they reference
+	"starSystemFilterExecutionOrder": [
+		"sentinel",
+		"namelessRock",
+		"domainCryosleeper",
+		"domainMothership",
+		"remnantStation",
+		"hypershunt",
+		"gate",
+		"sotf_MiasStar",
+		"barrenGateSystem",
+		"gasGiantGateSystem",
+		"rareOneSystemBuild",
+		"orbitalSolarArraySystem",
+		"miningBoreSystem",
+		"soilNanitesSystem",
+		"multiHabitableSystem",
+		"basicOneSystemBuild"
+	],
 
 	"starSystemFilters": {
 		"example": {
@@ -258,6 +261,32 @@
 				["domainCryosleeper", 10.0]
 			]
 		},
+		"rareOneSystemBuild": {
+			"filterName": "Rare one-system colony build",
+			"saveShorthand": "1SYS+",
+			"isEnabled": true,
+			"distanceFromCOM": 25,
+			"avoidTags": [
+				"theme_hidden",
+				"theme_core",
+				"theme_abyssal"
+			],
+			"hasPlanetsRequired": [
+				"habitablePlanet",
+				"farmingPlanet",
+				"noAtmospherePlanet",
+				"planetWithOres",
+				"planetWithOrganics",
+				"gasGiantAny"
+			],
+			"nearSystemFiltersRequired": [
+				"gate"
+			],
+			"nearSystemFiltersOptional": [
+				["hypershunt", 10.0],
+				["domainCryosleeper", 10.0]
+			]
+		},
 		"multiHabitableSystem": {
 			"filterName": "System with 3+ habitable planets",
 			"saveShorthand": "3HAB",
@@ -295,7 +324,7 @@
 	# All planet filters are component filters - they are not run standalone but used by system filters
 	"planetFilters": {
 		"example": {
-			# Name of the filter, which will be displayed on the report if saveShorthand is specified
+			# Name of the filter, this is what is displayed when a system report has a planet matching the filter
 			"filterName": "Example planet filter",
 
 			# Only planets with at most this hazard value will match (0-400, where 100 = 100% hazard)

--- a/src/org/tranquility/seedreporter/SEEDReport.java
+++ b/src/org/tranquility/seedreporter/SEEDReport.java
@@ -95,7 +95,7 @@ public class SEEDReport {
                 JSONObject planetFilterSetting = planetFilterList.optJSONObject(filterId);
                 if (planetFilterSetting == null) continue;
 
-                // Load all planet filters - they're either standalone (with saveShorthand) or components (used by system filters)
+                // Load all planet filters
                 PlanetFilter newFilter = new PlanetFilter(planetFilterSetting);
                 planetFilterMap.put(filterId, newFilter);
             }
@@ -117,15 +117,15 @@ public class SEEDReport {
     public String run() {
         centerOfMass = CommodityMarketData.computeCenterOfMass(null, null);
         
-        // Phase 1: Run all planet filters (no dependencies)
+        // Run all planet filters
         Map<String, Map<StarSystemAPI, Set<PlanetAPI>>> planetFilterResults = new HashMap<>();
         for (String filterId : planetFilterMap.keySet()) {
             PlanetFilter planetFilter = planetFilterMap.get(filterId);
             planetFilterResults.put(filterId, planetFilter.run());
         }
 
-        // Phase 2: Run all star system filters (can use planet filter results and other system filter results)
-        // Note: Filters are executed in order, so later filters can reference earlier ones via nearSystemFilters
+        // Run all star system filters (can use planet filter results and other system filter results)
+        // Filters are executed in order, so later filters can reference earlier ones via nearSystemFilters
         Map<String, Set<StarSystemAPI>> starSystemListMap = new HashMap<>();
         for (String filterId : starSystemFilterMap.keySet()) {
             StarSystemFilter systemFilter = starSystemFilterMap.get(filterId);

--- a/src/org/tranquility/seedreporter/filters/StarSystemFilter.java
+++ b/src/org/tranquility/seedreporter/filters/StarSystemFilter.java
@@ -1,13 +1,19 @@
 package org.tranquility.seedreporter.filters;
 
 import com.fs.starfarer.api.Global;
+import com.fs.starfarer.api.campaign.PlanetAPI;
 import com.fs.starfarer.api.campaign.SectorEntityToken;
 import com.fs.starfarer.api.campaign.StarSystemAPI;
+import com.fs.starfarer.api.util.Misc;
+import org.json.JSONArray;
 import org.json.JSONObject;
+import org.lwjgl.util.vector.Vector2f;
 import org.tranquility.seedreporter.SEEDUtils;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class StarSystemFilter {
@@ -17,6 +23,10 @@ public class StarSystemFilter {
     public Set<String> avoidTags;
     public Set<String> searchTags;
     public Set<String> entityTags;
+    public float distanceFromCOM;
+    public int numStableLocations;
+    public Set<String> hasPlanets;
+    public Map<String, Float> nearSystemFilters;  // System filter ID -> max distance in LY
 
     public StarSystemFilter(JSONObject settings) {
         filterName = settings.optString("filterName", "Star system filter locations");
@@ -26,9 +36,31 @@ public class StarSystemFilter {
         avoidTags = SEEDUtils.convertJSONArrayToSet(settings.optJSONArray("avoidTags"));
         searchTags = SEEDUtils.convertJSONArrayToSet(settings.optJSONArray("hasTags"));
         entityTags = SEEDUtils.convertJSONArrayToSet(settings.optJSONArray("hasEntityWithTags"));
+
+        distanceFromCOM = (float) settings.optDouble("distanceFromCOM", Float.MAX_VALUE);
+        numStableLocations = settings.optInt("numStableLocations", 0);
+        hasPlanets = SEEDUtils.convertJSONArrayToSet(settings.optJSONArray("hasPlanets"));
+
+        // Parse nearSystemFilters: either ["filterName"] or [["filterName", distance]]
+        JSONArray nearArray = settings.optJSONArray("nearSystemFilters");
+        if (nearArray != null) {
+            nearSystemFilters = new HashMap<>();
+            for (int i = 0; i < nearArray.length(); i++) {
+                JSONArray pairArray = nearArray.optJSONArray(i);
+                if (pairArray == null) {
+                    // Simple string format: ["filterName"] means 0 LY (must be in system)
+                    nearSystemFilters.put(nearArray.optString(i), 0f);
+                } else {
+                    // Pair format: [["filterName", distance]]
+                    nearSystemFilters.put(pairArray.optString(0), (float) pairArray.optDouble(1));
+                }
+            }
+        }
     }
 
-    public Set<StarSystemAPI> run() {
+    public Set<StarSystemAPI> run(Vector2f centerOfMass,
+                                   Map<String, Map<StarSystemAPI, Set<PlanetAPI>>> planetFilterResults,
+                                   Map<String, Set<StarSystemAPI>> starSystemListMap) {
         Set<StarSystemAPI> foundSystems = new HashSet<>();
 
         Iterable<StarSystemAPI> systems;
@@ -41,10 +73,16 @@ public class StarSystemFilter {
         }
 
         for (StarSystemAPI system : systems) {
+            // Check distance from center of mass
+            if (Misc.getDistanceLY(system.getLocation(), centerOfMass) > distanceFromCOM) continue;
+
+            // Check system tags to avoid
             if (avoidTags != null && !Collections.disjoint(system.getTags(), avoidTags)) continue;
 
+            // Check system must have all specified tags
             if (searchTags != null && !system.getTags().containsAll(searchTags)) continue;
 
+            // Check system must have entity with all specified tags
             if (entityTags != null) {
                 boolean foundEntity = false;
                 for (SectorEntityToken entity : system.getAllEntities())
@@ -53,6 +91,58 @@ public class StarSystemFilter {
                         break;
                     }
                 if (!foundEntity) continue;
+            }
+
+            // Check number of stable locations
+            if (numStableLocations > 0 && Misc.getNumStableLocations(system) < numStableLocations) continue;
+
+            // Check proximity to other system filters
+            if (nearSystemFilters != null && !nearSystemFilters.isEmpty()) {
+                boolean nearAllRequiredSystems = true;
+                for (String systemFilterId : nearSystemFilters.keySet()) {
+                    float maxDistance = nearSystemFilters.get(systemFilterId);
+
+                    // Check if this system filter exists and has results
+                    if (!starSystemListMap.containsKey(systemFilterId)) {
+                        nearAllRequiredSystems = false;
+                        break;
+                    }
+
+                    boolean nearThisFilter = false;
+                    if (maxDistance <= 0f) {
+                        // Distance 0 means must be IN one of the filter systems
+                        if (starSystemListMap.get(systemFilterId).contains(system))
+                            nearThisFilter = true;
+                    } else {
+                        // Check if within maxDistance of ANY system from this filter
+                        for (StarSystemAPI filterSystem : starSystemListMap.get(systemFilterId)) {
+                            if (Misc.getDistanceLY(filterSystem.getLocation(), system.getLocation()) <= maxDistance) {
+                                nearThisFilter = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (!nearThisFilter) {
+                        nearAllRequiredSystems = false;
+                        break;
+                    }
+                }
+                if (!nearAllRequiredSystems) continue;
+            }
+
+            // Check system contains all required planet types
+            if (hasPlanets != null && !hasPlanets.isEmpty()) {
+                boolean hasAllRequiredPlanets = true;
+                for (String planetFilterId : hasPlanets) {
+                    // Check if this planet filter exists and has results for this system
+                    if (!planetFilterResults.containsKey(planetFilterId) ||
+                        !planetFilterResults.get(planetFilterId).containsKey(system)) {
+                        hasAllRequiredPlanets = false;
+                        break;
+                    }
+                }
+                if (!hasAllRequiredPlanets) continue;
             }
 
             foundSystems.add(system);


### PR DESCRIPTION
>[!NOTE]
> Compiled and tested locally, not including a JAR as part of this PR, but I can if you like.
> If you choose to merge this PR, you should bump the major version and make a new release. These are breaking changes for existing configs

## Summary
I refactored SEEDReporter to enable multi-planet system searches (find a system with a habitable planet AND a planet with no atmosphere). Also added some additional filtering capabilities, including OR logic for planet requirements (find a system with either a terran planet OR a water planet), count-based planet requirements (find a system with a minimum of 3 habitable planets), and optional filters (nice-to-haves that show up in the report but don't filter a system out). I also fixed a bug with maxHazardRating, and made some changes to the printed output to support my changes.

## Changes:
In order to avoid a circular dependency, I had to remove the dependency on system filters from planet filters before making system filters depend on planet filters.

### PlanetFilter
I refactored PlanetFilter, removing everything that had to do with system level concerns (distanceFromCOM, avoidSystemTags, inStarSystemFilters, numStableLocations). PlanetFilter now only handles planet-specific properties, and has no dependence on other filters. It returns results grouped by system for efficient lookup. 

> [!IMPORTANT]
> Planet filters are always referenced by system filters, never printed directly in reports. In order to search for specific planets, you now configure a system with that planet.

### StarSystemFilter
StarSystemFilter now handles all system level concerns (distanceFromCOM, numStableLocations), and has a number of new fields: 
**hasPlanetsRequired**: Search for systems that have all of the specified planets
**hasPlanetsOneOf**: Search for systems that have at least one of the specified planets (limited to one OR block per filter, to keep things simple).
**hasPlanetsOptional**: Report if any of these planets are found in a system that otherwise passes the filter
```json
"hasPlanetsRequired": [
  ["habitablePlanet", 3],
  "barrenPlanet"
],
"hasPlanetsOneOf": ["gasGiantAny", "iceGiantAny"],
"hasPlanetsOptional": ["farmingPlanet"]
```

**nearSystemFiltersRequired**: This maintains the behavior of being able to search for systems that are in the proximity of another system (e.g. within 10 LY of a hypershunt).
**nearSystemFiltersOptional**: Report on matching near system filters, without filtering based on them.

> [!IMPORTANT]
> Because nearSystemFilters depend on other StarSystemFilters, the order that system filters are executed matters.
> Added a starSystemFilterExecutionOrder array that explicitly controls filter loading and execution order

```json
"nearSystemFiltersRequired": [
  "gate",                           # Must have a gate in system
  ["domainCryosleeper", 10.0],      # Within 10 LY of cryosleeper
  ["hypershunt", 10.0]              # Within 10 LY of hypershunt
]
```

### SEEDReport
SEEDReport now works as follows: Run all planet filters (no dependencies), then run all star system filters, making use of planet results. I removed the section for printing planet filters.

### Default config updates (seedreporterSettings.json)

Added a starSystemFilterExecutionOrder array in the config that explicitly controls filter loading and execution order.

Migrated everything to the new format. To search for specific planets, you now need to define a planet filter with the specified planet, and a system filter with `hasPlanetsRequired: ["yourPlanet"]`

Planet filters no longer need isEnabled, saveShorthand, distanceFromCOM, avoidSystemTags, inStarSystemFilters, numStableLocations

Star System Filters now support distanceFromCOM, numStableLocations, hasPlanets, and nearSystemFilters fields

Added a couple more system filters: basicOneSystemBuild and multiHabitableSystem, as well as supporting planet filters.

### Bugfix:

The max hazard value filter wasn't working correctly, so I fixed it. I changed it from an int to a float, and added conversion from percentage (175) to decimal (1.75)

### Example Output
```
========== Basic one-system colony build ==========
23.04 LY (17.68, 8.72) - Rama Star System
  200%, Mosrael (No atmosphere)
  75%, Vanara (Organics, Farmland, Ore + Rare Ore, Habitable)
  200%, Robinson's Moon (Ore + Rare Ore, No atmosphere)
  125%, Hanuman (Habitable)
  225%, Tuchulcha (Gas/Ice Giant)
23.42 LY (-24.38, 5.39) - Delta Avice Star System
  250%, Delta Avice II (Ore + Rare Ore)
  275%, Delta Avice V-A (Ore + Rare Ore)
  250%, Delta Avice I (Ore + Rare Ore)
  150%, Delta Avice IV (Organics, Farmland, Ore + Rare Ore, Habitable)
  175%, Delta Avice V-L5 (No atmosphere)
  175%, Delta Avice III (Ore + Rare Ore, No atmosphere)
  150%, Delta Avice V (Gas/Ice Giant)
  225%, Delta Avice V-L4 (Ore + Rare Ore)
  + Within 9.4 LY of 'Domain-era Cryosleeper locations' (Estrelya Star System)
13.42 LY (-13.46, -10.18) - Galaver Star System
  175%, Eros (Ore + Rare Ore, No atmosphere)
  150%, Agnolia (Organics, Farmland, Habitable)
  275%, Tartiflette (Ore + Rare Ore)
  200%, Ball (Ore + Rare Ore, No atmosphere)
  200%, Labraxas (Gas/Ice Giant)
  + Within 5.5 LY of 'Domain-era Cryosleeper locations' (Gamma Mel Texat Star System)
```
